### PR TITLE
feat(bundler): cross-module requires + robust module-call rewriting (Phase 3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,15 @@ OUTPUT_DIR=output
 ENTRY_FILE ?= example/myscript/main.lua
 OUTPUT_FILE ?= $(OUTPUT_DIR)/example_bundle.lua
 
+# ez-rbx-ui example smoke test (build every mode, serve one)
+SMOKE_ENTRY     ?= testdata/ez-rbx-ui/example/main.lua
+SMOKE_LIB_ENTRY ?= testdata/ez-rbx-ui/main.lua
+SMOKE_LIB_OUT   ?= testdata/ez-rbx-ui/output/bundle.lua
+SMOKE_DIR       ?= $(OUTPUT_DIR)/smoke
+SMOKE_MODE      ?= release-o3
+SMOKE_PORT      ?= 8080
+SMOKE_SERVE     ?= 1
+
 # Build information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%d_%H:%M:%S')
@@ -28,7 +37,7 @@ YELLOW=\033[1;33m
 RED=\033[0;31m
 NC=\033[0m # No Color
 
-.PHONY: all build clean test run help install deps fmt vet lint check release example verify-ezui
+.PHONY: all build clean test run help install deps fmt vet lint check release example verify-ezui smoke-test
 
 # Show help
 help:
@@ -46,10 +55,15 @@ help:
 	@echo "  $(YELLOW)check$(NC)        - Run fmt, vet, and lint"
 	@echo "  $(YELLOW)example$(NC)      - Build and run example"
 	@echo "  $(YELLOW)release$(NC)      - Create release build"
+	@echo "  $(YELLOW)verify-ezui$(NC)  - Build+run ez-rbx-ui under mocked Roblox (plain/-O2/-O3)"
+	@echo "  $(YELLOW)smoke-test$(NC)   - Build ez-rbx-ui example in all modes, then serve one"
 	@echo ""
 	@echo "$(GREEN)Configuration Variables:$(NC)"
 	@echo "  $(YELLOW)ENTRY_FILE$(NC)   - Entry Lua file (default: $(ENTRY_FILE))"
 	@echo "  $(YELLOW)OUTPUT_FILE$(NC)  - Output bundle file (default: $(OUTPUT_FILE))"
+	@echo "  $(YELLOW)SMOKE_MODE$(NC)   - smoke-test mode to serve (default: $(SMOKE_MODE))"
+	@echo "  $(YELLOW)SMOKE_PORT$(NC)   - smoke-test serve port (default: $(SMOKE_PORT))"
+	@echo "  $(YELLOW)SMOKE_SERVE$(NC)  - set 0 to build all modes without serving (default: $(SMOKE_SERVE))"
 	@echo ""
 	@echo "$(GREEN)Usage Examples:$(NC)"
 	@echo "  make run ENTRY_FILE=my_script.lua OUTPUT_FILE=my_bundle.lua"
@@ -61,8 +75,13 @@ deps:
 	@echo "$(GREEN)Downloading dependencies...$(NC)"
 	go mod download
 	go mod tidy
-	@echo "$(GREEN)Initializing git submodules...$(NC)"
-	git submodule update --init --recursive
+	@if git submodule status testdata/ez-rbx-ui 2>/dev/null | grep -q '^-'; then \
+		echo "$(GREEN)Initializing git submodule (ez-rbx-ui)...$(NC)"; \
+		git submodule update --init --recursive; \
+	else \
+		echo "$(YELLOW)ez-rbx-ui submodule already checked out — leaving your version as-is.$(NC)"; \
+		echo "$(YELLOW)  (run 'git submodule update --init --recursive' to reset it to the pinned version)$(NC)"; \
+	fi
 
 # Format code
 fmt:
@@ -194,6 +213,47 @@ verify-ezui: build
 	"$$BIN" -e main.lua -o output/bundle.lua --release -O 3 && \
 	lua5.1 scripts/verify_bundle.lua
 	@echo "$(GREEN)ez-rbx-ui plain, obfuscated (-O 2), and string-encrypted (-O 3) bundles all verified!$(NC)"
+
+# Build the ez-rbx-ui example playground in every mode
+# ({normal,release} x {O0,O1,O2,O3}), syntax-check each, then serve one
+# (SMOKE_MODE) so it can be loaded in Roblox via loadstring+HttpGet.
+#   make smoke-test                                  # build all 8, serve $(SMOKE_MODE) on :$(SMOKE_PORT)
+#   make smoke-test SMOKE_MODE=o2 SMOKE_PORT=8081    # serve a different mode/port
+#   make smoke-test SMOKE_SERVE=0                    # build + syntax-check all 8, don't serve (CI)
+smoke-test: build
+	@if [ ! -f "$(SMOKE_ENTRY)" ]; then \
+		echo "$(YELLOW)ez-rbx-ui submodule missing — run: git submodule update --init --recursive$(NC)"; \
+		exit 1; \
+	fi
+	@mkdir -p "$(SMOKE_DIR)" "$(dir $(SMOKE_LIB_OUT))"
+	@BIN="$(CURDIR)/$(BUILD_DIR)/$(BINARY_NAME)"; \
+	echo "$(GREEN)Building ez-rbx-ui library bundle (example dependency)...$(NC)"; \
+	"$$BIN" -e "$(SMOKE_LIB_ENTRY)" -o "$(SMOKE_LIB_OUT)" >/dev/null || { echo "$(RED)library bundle failed$(NC)"; exit 1; }; \
+	echo "$(GREEN)Building example in all modes -> $(SMOKE_DIR)/$(NC)"; \
+	fail=0; serveflags=""; servefound=0; \
+	for spec in "normal:" "o1:-O 1" "o2:-O 2" "o3:-O 3" "release:--release" "release-o1:--release -O 1" "release-o2:--release -O 2" "release-o3:--release -O 3"; do \
+		name="$${spec%%:*}"; flags="$${spec#*:}"; \
+		out="$(SMOKE_DIR)/ezui-$$name.lua"; \
+		printf "  %-12s " "$$name"; \
+		if "$$BIN" -e "$(SMOKE_ENTRY)" -o "$$out" $$flags >/dev/null 2>&1 && [ -s "$$out" ]; then \
+			if command -v luac5.1 >/dev/null 2>&1 && ! luac5.1 -p "$$out" >/dev/null 2>&1; then \
+				echo "$(RED)PARSE FAILED$(NC)"; fail=1; \
+			else \
+				echo "$(GREEN)OK$(NC) ($$(wc -c < "$$out") bytes)"; \
+			fi; \
+		else \
+			echo "$(RED)BUNDLE FAILED$(NC)"; fail=1; \
+		fi; \
+		if [ "$$name" = "$(SMOKE_MODE)" ]; then serveflags="$$flags"; servefound=1; fi; \
+	done; \
+	if [ "$$fail" -ne 0 ]; then echo "$(RED)smoke-test: one or more modes failed$(NC)"; exit 1; fi; \
+	echo "$(GREEN)All 8 modes built and parse OK.$(NC)"; \
+	if [ "$(SMOKE_SERVE)" != "1" ]; then echo "$(YELLOW)SMOKE_SERVE=0 — skipping serve.$(NC)"; exit 0; fi; \
+	if [ "$$servefound" -ne 1 ]; then \
+		echo "$(RED)Unknown SMOKE_MODE='$(SMOKE_MODE)' (valid: normal o1 o2 o3 release release-o1 release-o2 release-o3)$(NC)"; exit 1; \
+	fi; \
+	echo "$(GREEN)Serving '$(SMOKE_MODE)' on :$(SMOKE_PORT) — in Roblox: loadstring(game:HttpGet('http://localhost:$(SMOKE_PORT)/ezui-$(SMOKE_MODE).lua'))()$(NC)"; \
+	"$$BIN" -e "$(SMOKE_ENTRY)" -o "$(SMOKE_DIR)/ezui-$(SMOKE_MODE).lua" $$serveflags --serve --port $(SMOKE_PORT)
 
 # Create release build (optimized)
 release: check

--- a/internal/bundler/bundler.go
+++ b/internal/bundler/bundler.go
@@ -88,6 +88,9 @@ func (b *Bundler) Bundle(releaseMode bool) (string, error) {
 		return "", err
 	}
 
+	// Rewrite module calls on the entry (raw source) before obfuscation.
+	mainContent = b.rewriteModuleCalls(mainContent, b.entryFile)
+
 	// Obfuscate main content (entry file) if obfuscation is enabled
 	if b.obfuscateLevel > 0 && b.obfuscator != nil {
 		mainContent = b.obfuscator.Obfuscate(mainContent)

--- a/internal/bundler/crossmodule_test.go
+++ b/internal/bundler/crossmodule_test.go
@@ -19,6 +19,40 @@ func findLua() string {
 	return ""
 }
 
+func TestBundle_RemoteModuleBodyRewritten(t *testing.T) {
+	dir := t.TempDir()
+	write := func(p, s string) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, p), []byte(s), 0o644))
+	}
+	leaf := "file://" + filepath.Join(dir, "leaf.lua")
+	remote := "file://" + filepath.Join(dir, "remote.lua")
+	write("leaf.lua", `return { tag = "LEAF" }`)
+	// remote module's BODY pulls the leaf via HttpGet — must be rewritten to loadModule.
+	write("remote.lua", `local L = loadstring(game:HttpGet("`+leaf+`"))()
+return { leaf = L.tag }`)
+	write("main.lua", `local R = loadstring(game:HttpGet("`+remote+`"))()
+print("remote.leaf="..R.leaf)`)
+
+	b, err := NewBundler(filepath.Join(dir, "main.lua"), false, false)
+	require.NoError(t, err)
+	out, err := b.Bundle(false)
+	require.NoError(t, err)
+
+	// Both remote and leaf embedded (discovery), and the remote BODY must call loadModule(leaf), not raw HttpGet.
+	assert.Contains(t, b.GetModules(), remote)
+	assert.Contains(t, b.GetModules(), leaf)
+	assert.Contains(t, out, `loadModule("`+leaf+`")`, "remote module body's HttpGet must be rewritten to loadModule")
+
+	if lua := findLua(); lua != "" {
+		bp := filepath.Join(dir, "bundle.lua")
+		require.NoError(t, os.WriteFile(bp, []byte(out), 0o644))
+		got, rerr := exec.Command(lua, bp).CombinedOutput()
+		require.NoErrorf(t, rerr, "bundle failed to run: %s", got)
+		assert.Contains(t, string(got), "remote.leaf=LEAF",
+			"remote module must resolve its leaf via the embedded loadModule (got: %s)", got)
+	}
+}
+
 func TestBundle_CrossModuleRequire_RunsAndMemoizes(t *testing.T) {
 	dir := t.TempDir()
 	write := func(p, s string) {

--- a/internal/bundler/crossmodule_test.go
+++ b/internal/bundler/crossmodule_test.go
@@ -1,0 +1,60 @@
+package bundler
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func findLua() string {
+	for _, n := range []string{"lua5.1", "lua"} {
+		if p, err := exec.LookPath(n); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+func TestBundle_CrossModuleRequire_RunsAndMemoizes(t *testing.T) {
+	dir := t.TempDir()
+	write := func(p, s string) {
+		require.NoError(t, os.MkdirAll(filepath.Dir(filepath.Join(dir, p)), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, p), []byte(s), 0o644))
+	}
+	// b.lua: shared module with a load counter; entry does NOT require it directly.
+	write("b.lua", `_G.bloads = (_G.bloads or 0) + 1
+return { n = _G.bloads }`)
+	// a.lua and c.lua both require b (cross-module).
+	write("a.lua", `local B = require("b")
+return { v = function() return B.n end }`)
+	write("c.lua", `local B = require("b")
+return { v = function() return B.n end }`)
+	// entry requires a and c only; prints whether both see the same single load.
+	write("main.lua", `local A = require("a")
+local C = require("c")
+print("A="..A.v().." C="..C.v().." loads=".._G.bloads)`)
+
+	b, err := NewBundler(filepath.Join(dir, "main.lua"), false, false)
+	require.NoError(t, err)
+	out, err := b.Bundle(false)
+	require.NoError(t, err)
+
+	// b.lua must be embedded once under canonical key "b" even though only A/C require it.
+	assert.Contains(t, b.GetModules(), "b", "shared module must be discovered via cross-module require")
+
+	lua := findLua()
+	if lua == "" {
+		t.Skip("no lua5.1/lua on PATH; cannot run cross-module bundle")
+	}
+	bundlePath := filepath.Join(dir, "bundle.lua")
+	require.NoError(t, os.WriteFile(bundlePath, []byte(out), 0o644))
+	got, rerr := exec.Command(lua, bundlePath).CombinedOutput()
+	require.NoErrorf(t, rerr, "cross-module bundle failed to run: %s", got)
+	// Memoization: b loaded once → A and C both see n=1, loads=1.
+	assert.Contains(t, string(got), "A=1 C=1 loads=1",
+		"shared module must load exactly once (got: %s)", got)
+}

--- a/internal/bundler/generator.go
+++ b/internal/bundler/generator.go
@@ -6,6 +6,14 @@ import (
 	"strings"
 )
 
+// Module-call detection patterns, compiled once and shared by discovery
+// (processFile) and rewriting (rewriteModuleCalls).
+var (
+	moduleRequireRegex    = regexp.MustCompile(`require\s*\(\s*['"]([^'"]+)['"]\s*\)`)
+	moduleHTTPGetRegex    = regexp.MustCompile(`loadstring\s*\(\s*game:HttpGet\s*\(\s*['"]([^'"]+)['"]\s*\)\s*\)\s*\(\s*\)`)
+	moduleFuncWrapHTTPGet = regexp.MustCompile(`\w+\s*\([^)]*loadstring\s*\(\s*game:HttpGet`)
+)
+
 // generateBundle creates the final bundled output
 func (b *Bundler) generateBundle(mainContent string) string {
 	var output strings.Builder
@@ -68,20 +76,16 @@ func (b *Bundler) generateBundle(mainContent string) string {
 // on raw (pre-obfuscation) source, so the function-wrapped-HttpGet skip is
 // evaluated on readable, multi-line text.
 func (b *Bundler) rewriteModuleCalls(content, currentFile string) string {
-	requireRegex := regexp.MustCompile(`require\s*\(\s*['"]([^'"]+)['"]\s*\)`)
-	httpGetRegex := regexp.MustCompile(`loadstring\s*\(\s*game:HttpGet\s*\(\s*['"]([^'"]+)['"]\s*\)\s*\)\s*\(\s*\)`)
-	funcCallHttpGetRegex := regexp.MustCompile(`\w+\s*\([^)]*loadstring\s*\(\s*game:HttpGet`)
-
 	processed := content
 
 	// Replace direct loadstring(game:HttpGet(url))() — skip lines where it's wrapped in a call.
 	lines := strings.Split(processed, "\n")
 	for i, line := range lines {
-		if funcCallHttpGetRegex.MatchString(line) {
+		if moduleFuncWrapHTTPGet.MatchString(line) {
 			continue
 		}
-		lines[i] = httpGetRegex.ReplaceAllStringFunc(line, func(match string) string {
-			m := httpGetRegex.FindStringSubmatch(match)
+		lines[i] = moduleHTTPGetRegex.ReplaceAllStringFunc(line, func(match string) string {
+			m := moduleHTTPGetRegex.FindStringSubmatch(match)
 			if len(m) > 1 {
 				return fmt.Sprintf("loadModule(\"%s\")", escapeString(m[1]))
 			}
@@ -91,8 +95,8 @@ func (b *Bundler) rewriteModuleCalls(content, currentFile string) string {
 	processed = strings.Join(lines, "\n")
 
 	// Replace local require() with loadModule(canonicalKey).
-	processed = requireRegex.ReplaceAllStringFunc(processed, func(match string) string {
-		m := requireRegex.FindStringSubmatch(match)
+	processed = moduleRequireRegex.ReplaceAllStringFunc(processed, func(match string) string {
+		m := moduleRequireRegex.FindStringSubmatch(match)
 		if len(m) > 1 && b.isLocalModule(m[1]) {
 			return fmt.Sprintf("loadModule(\"%s\")", escapeString(b.canonicalKey(currentFile, m[1])))
 		}

--- a/internal/bundler/generator.go
+++ b/internal/bundler/generator.go
@@ -56,56 +56,50 @@ func (b *Bundler) generateBundle(mainContent string) string {
 	output.WriteString("    return require(url)\n")
 	output.WriteString("end\n\n")
 
-	// Replace require() and loadstring() in main content
-	processedMain := b.replaceModuleCalls(mainContent)
-
 	output.WriteString("-- Main Script\n")
-	output.WriteString(processedMain)
+	output.WriteString(mainContent)
 
 	return output.String()
 }
 
-// replaceModuleCalls replaces require() and loadstring() calls with loadModule() calls
-func (b *Bundler) replaceModuleCalls(content string) string {
+// rewriteModuleCalls rewrites local require() and direct loadstring(HttpGet())()
+// calls in content into loadModule(canonicalKey) calls. currentFile gives the
+// caller's location so relative require paths resolve to canonical keys. It runs
+// on raw (pre-obfuscation) source, so the function-wrapped-HttpGet skip is
+// evaluated on readable, multi-line text.
+func (b *Bundler) rewriteModuleCalls(content, currentFile string) string {
 	requireRegex := regexp.MustCompile(`require\s*\(\s*['"]([^'"]+)['"]\s*\)`)
 	httpGetRegex := regexp.MustCompile(`loadstring\s*\(\s*game:HttpGet\s*\(\s*['"]([^'"]+)['"]\s*\)\s*\)\s*\(\s*\)`)
-	// Pattern to detect HttpGet inside function calls (should NOT be replaced)
 	funcCallHttpGetRegex := regexp.MustCompile(`\w+\s*\([^)]*loadstring\s*\(\s*game:HttpGet`)
 
-	processedContent := content
+	processed := content
 
-	// Replace loadstring(game:HttpGet(...))() - but skip if inside function calls
-	lines := strings.Split(processedContent, "\n")
+	// Replace direct loadstring(game:HttpGet(url))() — skip lines where it's wrapped in a call.
+	lines := strings.Split(processed, "\n")
 	for i, line := range lines {
-		// Skip lines with HttpGet inside function calls
 		if funcCallHttpGetRegex.MatchString(line) {
 			continue
 		}
-		// Replace HttpGet pattern in this line
 		lines[i] = httpGetRegex.ReplaceAllStringFunc(line, func(match string) string {
-			matches := httpGetRegex.FindStringSubmatch(match)
-			if len(matches) > 1 {
-				url := matches[1]
-				return fmt.Sprintf("loadModule(\"%s\")", escapeString(url))
+			m := httpGetRegex.FindStringSubmatch(match)
+			if len(m) > 1 {
+				return fmt.Sprintf("loadModule(\"%s\")", escapeString(m[1]))
 			}
 			return match
 		})
 	}
-	processedContent = strings.Join(lines, "\n")
+	processed = strings.Join(lines, "\n")
 
-	// Replace require() for local files
-	processedContent = requireRegex.ReplaceAllStringFunc(processedContent, func(match string) string {
-		matches := requireRegex.FindStringSubmatch(match)
-		if len(matches) > 1 {
-			modulePath := matches[1]
-			if b.isLocalModule(modulePath) {
-				return fmt.Sprintf("loadModule(\"%s\")", escapeString(modulePath))
-			}
+	// Replace local require() with loadModule(canonicalKey).
+	processed = requireRegex.ReplaceAllStringFunc(processed, func(match string) string {
+		m := requireRegex.FindStringSubmatch(match)
+		if len(m) > 1 && b.isLocalModule(m[1]) {
+			return fmt.Sprintf("loadModule(\"%s\")", escapeString(b.canonicalKey(currentFile, m[1])))
 		}
 		return match
 	})
 
-	return processedContent
+	return processed
 }
 
 // escapeString escapes special characters in strings for Lua

--- a/internal/bundler/generator.go
+++ b/internal/bundler/generator.go
@@ -52,15 +52,16 @@ func (b *Bundler) generateBundle(mainContent string) string {
 		output.WriteString("end\n\n")
 	}
 
-	// Add loadModule function
-	output.WriteString("-- Load module helper function\n")
+	// Add loadModule function (memoized, like require)
+	output.WriteString("-- Load module helper (memoized, like require)\n")
+	output.WriteString("local _cache, _cached = {}, {}\n")
 	output.WriteString("local function loadModule(url)\n")
-	output.WriteString("    -- Try embedded module first\n")
+	output.WriteString("    if _cached[url] then return _cache[url] end\n")
 	output.WriteString("    if EmbeddedModules[url] then\n")
-	output.WriteString("        return EmbeddedModules[url]()\n")
+	output.WriteString("        _cache[url] = EmbeddedModules[url]()\n")
+	output.WriteString("        _cached[url] = true\n")
+	output.WriteString("        return _cache[url]\n")
 	output.WriteString("    end\n")
-	output.WriteString("    \n")
-	output.WriteString("    -- Fallback to original require\n")
 	output.WriteString("    return require(url)\n")
 	output.WriteString("end\n\n")
 

--- a/internal/bundler/generator.go
+++ b/internal/bundler/generator.go
@@ -34,6 +34,19 @@ func (b *Bundler) generateBundle(mainContent string) string {
 	// Generate EmbeddedModules table
 	output.WriteString("local EmbeddedModules = {}\n\n")
 
+	// Add loadModule function (memoized, like require)
+	output.WriteString("-- Load module helper (memoized, like require)\n")
+	output.WriteString("local _cache, _cached = {}, {}\n")
+	output.WriteString("local function loadModule(url)\n")
+	output.WriteString("    if _cached[url] then return _cache[url] end\n")
+	output.WriteString("    if EmbeddedModules[url] then\n")
+	output.WriteString("        _cache[url] = EmbeddedModules[url]()\n")
+	output.WriteString("        _cached[url] = true\n")
+	output.WriteString("        return _cache[url]\n")
+	output.WriteString("    end\n")
+	output.WriteString("    return require(url)\n")
+	output.WriteString("end\n\n")
+
 	// Add all modules
 	for path, content := range b.modules {
 		output.WriteString(fmt.Sprintf("-- Module: %s\n", path))
@@ -51,19 +64,6 @@ func (b *Bundler) generateBundle(mainContent string) string {
 
 		output.WriteString("end\n\n")
 	}
-
-	// Add loadModule function (memoized, like require)
-	output.WriteString("-- Load module helper (memoized, like require)\n")
-	output.WriteString("local _cache, _cached = {}, {}\n")
-	output.WriteString("local function loadModule(url)\n")
-	output.WriteString("    if _cached[url] then return _cache[url] end\n")
-	output.WriteString("    if EmbeddedModules[url] then\n")
-	output.WriteString("        _cache[url] = EmbeddedModules[url]()\n")
-	output.WriteString("        _cached[url] = true\n")
-	output.WriteString("        return _cache[url]\n")
-	output.WriteString("    end\n")
-	output.WriteString("    return require(url)\n")
-	output.WriteString("end\n\n")
 
 	output.WriteString("-- Main Script\n")
 	output.WriteString(mainContent)

--- a/internal/bundler/generator_test.go
+++ b/internal/bundler/generator_test.go
@@ -291,6 +291,23 @@ func TestRewriteModuleCalls_DirectHttpGet(t *testing.T) {
 	}
 }
 
+func TestGenerateBundle_LoadModuleDeclaredBeforeClosures(t *testing.T) {
+	b, err := NewBundler("test.lua", false, false)
+	require.NoError(t, err)
+	b.modules["a"] = `local B = loadModule("b") return B`
+	b.modules["b"] = `return 1`
+	out := b.generateBundle("return loadModule(\"a\")")
+
+	di := strings.Index(out, "local function loadModule")
+	ci := strings.Index(out, "EmbeddedModules[\"")
+	if di < 0 || ci < 0 {
+		t.Fatalf("missing loadModule decl or EmbeddedModules assignment:\n%s", out)
+	}
+	if di > ci {
+		t.Fatalf("loadModule must be declared BEFORE EmbeddedModules closures (d=%d c=%d) so closures capture it as an upvalue", di, ci)
+	}
+}
+
 func TestGenerateBundle_LoadModuleMemoizes(t *testing.T) {
 	b, err := NewBundler("test.lua", false, false)
 	require.NoError(t, err)

--- a/internal/bundler/generator_test.go
+++ b/internal/bundler/generator_test.go
@@ -1,6 +1,8 @@
 package bundler
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,12 +27,14 @@ function remote.fetch()
 end
 return remote`
 
-	mainContent := `local helper = require('./helper.lua')
+	rawContent := `local helper = require('./helper.lua')
 local remote = loadstring(game:HttpGet('https://example.com/remote.lua'))()
 
 print(helper.greet())
 print(remote.fetch())`
 
+	// Simulate the pipeline: rewrite calls before passing to generateBundle.
+	mainContent := b.rewriteModuleCalls(rawContent, "test.lua")
 	result := b.generateBundle(mainContent)
 
 	tests := []struct {
@@ -79,7 +83,8 @@ print(remote.fetch())`
 		{
 			name: "replaces require calls",
 			check: func(s string) bool {
-				return strings.Contains(s, `loadModule("./helper.lua")`) &&
+				// rewriteModuleCalls uses canonical keys (no leading "./" or ".lua" suffix).
+				return strings.Contains(s, `loadModule("helper")`) &&
 					!strings.Contains(s, `require('./helper.lua')`)
 			},
 			message: "should replace require calls with loadModule",
@@ -237,5 +242,42 @@ return test`
 				assert.True(t, strings.HasPrefix(line, "    "), "Module line should be indented with 4 spaces: %q", line)
 			}
 		}
+	}
+}
+
+func TestRewriteModuleCalls_ModuleBodyCanonical(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "core"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "components"), 0o755))
+	for _, p := range []string{"main.lua", "core/theme.lua", "components/button.lua"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, p), []byte("return {}"), 0o644))
+	}
+	b, err := NewBundler(filepath.Join(dir, "main.lua"), false, false)
+	require.NoError(t, err)
+
+	button := filepath.Join(dir, "components/button.lua")
+	// button.lua requires the shared core/theme via a relative path
+	got := b.rewriteModuleCalls(`local T = require("../core/theme")`, button)
+	if !strings.Contains(got, `loadModule("core/theme")`) {
+		t.Fatalf("module-body require not rewritten to canonical loadModule: %q", got)
+	}
+}
+
+func TestRewriteModuleCalls_SkipsFunctionWrappedHttpGet(t *testing.T) {
+	b, err := NewBundler("x.lua", false, false)
+	require.NoError(t, err)
+	in := `queue_on_teleport("loadstring(game:HttpGet('https://e/x.lua'))()")`
+	if got := b.rewriteModuleCalls(in, "x.lua"); got != in {
+		t.Fatalf("function-wrapped HttpGet must NOT be rewritten: %q", got)
+	}
+}
+
+func TestRewriteModuleCalls_DirectHttpGet(t *testing.T) {
+	b, err := NewBundler("x.lua", false, false)
+	require.NoError(t, err)
+	in := `loadstring(game:HttpGet("https://e/x.lua"))()`
+	got := b.rewriteModuleCalls(in, "x.lua")
+	if !strings.Contains(got, `loadModule("https://e/x.lua")`) {
+		t.Fatalf("direct HttpGet must be rewritten: %q", got)
 	}
 }

--- a/internal/bundler/generator_test.go
+++ b/internal/bundler/generator_test.go
@@ -290,3 +290,18 @@ func TestRewriteModuleCalls_DirectHttpGet(t *testing.T) {
 		t.Fatalf("direct HttpGet must be rewritten: %q", got)
 	}
 }
+
+func TestGenerateBundle_LoadModuleMemoizes(t *testing.T) {
+	b, err := NewBundler("test.lua", false, false)
+	require.NoError(t, err)
+	out := b.generateBundle("return 1")
+	// The helper must cache: a second loadModule(url) returns the cached value
+	// rather than re-invoking EmbeddedModules[url].
+	if !strings.Contains(out, "EmbeddedModules[url]()") {
+		t.Fatalf("loadModule should still invoke embedded modules: %s", out)
+	}
+	// A cache table + a cached-flag table must be present.
+	if !strings.Contains(out, "_cache") || !strings.Contains(out, "_cached") {
+		t.Fatalf("loadModule must memoize via _cache/_cached: %s", out)
+	}
+}

--- a/internal/bundler/generator_test.go
+++ b/internal/bundler/generator_test.go
@@ -272,6 +272,15 @@ func TestRewriteModuleCalls_SkipsFunctionWrappedHttpGet(t *testing.T) {
 	}
 }
 
+func TestRewriteModuleCalls_SkipsBareFunctionWrappedHttpGet(t *testing.T) {
+	b, err := NewBundler("x.lua", false, false)
+	require.NoError(t, err)
+	in := `queue_on_teleport(loadstring(game:HttpGet("https://e/x.lua"))())`
+	if got := b.rewriteModuleCalls(in, "x.lua"); got != in {
+		t.Fatalf("bare function-wrapped HttpGet must NOT be rewritten: %q", got)
+	}
+}
+
 func TestRewriteModuleCalls_DirectHttpGet(t *testing.T) {
 	b, err := NewBundler("x.lua", false, false)
 	require.NoError(t, err)

--- a/internal/bundler/processor.go
+++ b/internal/bundler/processor.go
@@ -176,9 +176,10 @@ func (b *Bundler) processFile(filePath string, content string) error {
 			// Process local files (relative, absolute from base, or subdirectory)
 			if b.isLocalModule(modulePath) {
 				resolvedPath := b.resolveModulePath(filePath, modulePath)
+				key := b.canonicalKey(filePath, modulePath)
 
-				// Skip if already processed
-				if _, exists := b.modules[modulePath]; exists {
+				// Skip if already processed (by canonical key)
+				if _, exists := b.modules[key]; exists {
 					continue
 				}
 
@@ -198,13 +199,13 @@ func (b *Bundler) processFile(filePath string, content string) error {
 					moduleContent = b.obfuscator.Obfuscate(moduleContent)
 				}
 
-				b.modules[modulePath] = moduleContent
+				b.modules[key] = moduleContent
 
 				if b.verbose {
-					fmt.Printf("📄 Processed: %s\n", modulePath)
+					fmt.Printf("📄 Processed: %s\n", key)
 				}
 
-				// Process file recursively
+				// Process file recursively (pass raw fileContent so nested requires remain intact)
 				if err := b.processFile(resolvedPath, string(fileContent)); err != nil {
 					return err
 				}

--- a/internal/bundler/processor.go
+++ b/internal/bundler/processor.go
@@ -152,12 +152,19 @@ func (b *Bundler) processFile(filePath string, content string) error {
 			// Apply env var substitution to HTTP module content
 			httpContent = substituteEnvVars(httpContent, b.envVars, b.verbose)
 
+			// Rewrite nested HttpGet/require calls before storing, so the embedded
+			// body calls loadModule() instead of live-fetching at runtime.
+			// Pass the raw (pre-rewrite) content to processFile so the HttpGet
+			// patterns are still present for nested dependency discovery.
+			rawHTTPContent := httpContent
+			httpContent = b.rewriteModuleCalls(httpContent, url)
+
 			// Mark as HTTP module (do not obfuscate)
 			b.httpModules[url] = true
 			b.modules[url] = httpContent
 
-			// Process downloaded content (might have requires in it)
-			if err := b.processFile(url, httpContent); err != nil {
+			// Process raw downloaded content (might have nested requires/HttpGets in it)
+			if err := b.processFile(url, rawHTTPContent); err != nil {
 				return err
 			}
 		}

--- a/internal/bundler/processor.go
+++ b/internal/bundler/processor.go
@@ -193,6 +193,7 @@ func (b *Bundler) processFile(filePath string, content string) error {
 
 				// Apply env var substitution before obfuscation
 				moduleContent = substituteEnvVars(moduleContent, b.envVars, b.verbose)
+				moduleContent = b.rewriteModuleCalls(moduleContent, resolvedPath)
 
 				// Obfuscate local module if obfuscation is enabled
 				if b.obfuscateLevel > 0 && b.obfuscator != nil {

--- a/internal/bundler/processor.go
+++ b/internal/bundler/processor.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -127,22 +126,16 @@ func (b *Bundler) canonicalKey(currentFile, modulePath string) string {
 
 // processFile recursively processes a file and its dependencies
 func (b *Bundler) processFile(filePath string, content string) error {
-	// Regex patterns
-	requireRegex := regexp.MustCompile(`require\s*\(\s*['"]([^'"]+)['"]\s*\)`)
-	httpGetRegex := regexp.MustCompile(`loadstring\s*\(\s*game:HttpGet\s*\(\s*['"]([^'"]+)['"]\s*\)\s*\)\s*\(\s*\)`)
-	// Pattern to detect HttpGet inside function calls (should NOT be bundled)
-	funcCallHttpGetRegex := regexp.MustCompile(`\w+\s*\([^)]*loadstring\s*\(\s*game:HttpGet`)
-
 	lines := strings.Split(content, "\n")
 
 	for _, line := range lines {
 		// Skip if HttpGet is inside a function call (e.g., queue_on_teleport("loadstring(...)"))
-		if funcCallHttpGetRegex.MatchString(line) {
+		if moduleFuncWrapHTTPGet.MatchString(line) {
 			continue
 		}
 
 		// Check for loadstring(game:HttpGet(...))()
-		if matches := httpGetRegex.FindStringSubmatch(line); len(matches) > 1 {
+		if matches := moduleHTTPGetRegex.FindStringSubmatch(line); len(matches) > 1 {
 			url := matches[1]
 
 			// Skip if already processed
@@ -170,7 +163,7 @@ func (b *Bundler) processFile(filePath string, content string) error {
 		}
 
 		// Check for local require()
-		if matches := requireRegex.FindStringSubmatch(line); len(matches) > 1 {
+		if matches := moduleRequireRegex.FindStringSubmatch(line); len(matches) > 1 {
 			modulePath := matches[1]
 
 			// Process local files (relative, absolute from base, or subdirectory)

--- a/internal/bundler/processor.go
+++ b/internal/bundler/processor.go
@@ -111,6 +111,20 @@ func (b *Bundler) resolveModulePath(currentFile, modulePath string) string {
 	return resolvedPath
 }
 
+// canonicalKey is the EmbeddedModules key for a local module required as
+// modulePath from currentFile: the resolved file path made relative to baseDir,
+// cleaned, forward-slashed, with any trailing ".lua" removed. The same file
+// required from different callers/spellings collapses to one key.
+func (b *Bundler) canonicalKey(currentFile, modulePath string) string {
+	resolved := b.resolveModulePath(currentFile, modulePath)
+	rel, err := filepath.Rel(b.baseDir, resolved)
+	if err != nil {
+		rel = resolved
+	}
+	rel = filepath.ToSlash(filepath.Clean(rel))
+	return strings.TrimSuffix(rel, ".lua")
+}
+
 // processFile recursively processes a file and its dependencies
 func (b *Bundler) processFile(filePath string, content string) error {
 	// Regex patterns

--- a/internal/bundler/processor_test.go
+++ b/internal/bundler/processor_test.go
@@ -162,3 +162,33 @@ func TestCanonicalKey(t *testing.T) {
 		}
 	}
 }
+
+func TestProcessFile_KeysByCanonical(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "core"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "core/util.lua"), []byte("return {}"), 0o644))
+	// entry requires it WITH a .lua suffix; key must canonicalize to "core/util"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.lua"),
+		[]byte(`local U = require("core/util.lua")`+"\nreturn U"), 0o644))
+
+	b, err := NewBundler(filepath.Join(dir, "main.lua"), false, false)
+	require.NoError(t, err)
+	_, err = b.Bundle(false)
+	require.NoError(t, err)
+
+	mods := b.GetModules()
+	if _, ok := mods["core/util"]; !ok {
+		t.Fatalf("expected canonical key %q, got keys: %v", "core/util", keysOf(mods))
+	}
+	if _, ok := mods["core/util.lua"]; ok {
+		t.Fatalf("must not key by the as-written .lua spelling")
+	}
+}
+
+func keysOf(m map[string]string) []string {
+	var k []string
+	for key := range m {
+		k = append(k, key)
+	}
+	return k
+}

--- a/internal/bundler/processor_test.go
+++ b/internal/bundler/processor_test.go
@@ -1,6 +1,8 @@
 package bundler
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -131,5 +133,32 @@ func TestResolveModulePath(t *testing.T) {
 			got := b.resolveModulePath(tt.currentFile, tt.modulePath)
 			assert.Equal(t, tt.want, got, "resolveModulePath(%q, %q) should return correct path", tt.currentFile, tt.modulePath)
 		})
+	}
+}
+
+func TestCanonicalKey(t *testing.T) {
+	dir := t.TempDir()
+	// layout: <dir>/main.lua, <dir>/core/theme.lua, <dir>/components/button.lua
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "core"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "components"), 0o755))
+	for _, p := range []string{"main.lua", "core/theme.lua", "components/button.lua"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, p), []byte("return {}"), 0o644))
+	}
+	b, err := NewBundler(filepath.Join(dir, "main.lua"), false, false)
+	require.NoError(t, err)
+
+	entry := filepath.Join(dir, "main.lua")
+	button := filepath.Join(dir, "components/button.lua")
+	cases := []struct{ cur, mod, want string }{
+		{entry, "core/theme", "core/theme"},
+		{entry, "core/theme.lua", "core/theme"},
+		{button, "../core/theme", "core/theme"},  // same module, different caller/spelling
+		{button, "./sibling", "components/sibling"},
+		{entry, "/core/theme", "core/theme"}, // base-relative spelling
+	}
+	for _, c := range cases {
+		if got := b.canonicalKey(c.cur, c.mod); got != c.want {
+			t.Errorf("canonicalKey(%q,%q)=%q want %q", c.cur, c.mod, got, c.want)
+		}
 	}
 }

--- a/internal/bundler/queue_teleport_test.go
+++ b/internal/bundler/queue_teleport_test.go
@@ -50,7 +50,7 @@ print("test")`,
 				verbose:     false,
 			}
 
-			result := b.replaceModuleCalls(tt.content)
+			result := b.rewriteModuleCalls(tt.content, "/tmp/test.lua")
 
 			// Check if HttpGet pattern was replaced with loadModule
 			containsLoadModule := strings.Contains(result, `loadModule("https://example.com/`)
@@ -106,9 +106,9 @@ func TestQueueOnTeleportVariations(t *testing.T) {
 				verbose:     false,
 			}
 
-			got := b.replaceModuleCalls(tt.input)
+			got := b.rewriteModuleCalls(tt.input, "/tmp/test.lua")
 			if got != tt.want {
-				t.Errorf("replaceModuleCalls() got = %v, want %v", got, tt.want)
+				t.Errorf("rewriteModuleCalls() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/lua/strenc.go
+++ b/internal/lua/strenc.go
@@ -278,13 +278,15 @@ func (e *encryptor) encode(s *StringExpr) (Expr, bool) {
 	}, true
 }
 
-// isProtectedCall reports whether v is a require(...) or X:HttpGet(...) call
-// whose string argument must not be encrypted.
+// isProtectedCall reports whether v is a require(...), loadModule(...), or
+// X:HttpGet(...) call whose string argument must not be encrypted.
+// loadModule is included because rewriteModuleCalls rewrites require() into
+// loadModule() before obfuscation runs; the key must survive as a literal.
 func isProtectedCall(v *CallExpr) bool {
 	fn := unwrapParen(v.Fn)
 	switch f := fn.(type) {
 	case *NameExpr:
-		return f.Name == "require"
+		return f.Name == "require" || f.Name == "loadModule"
 	case *IndexExpr:
 		return f.IsMethod && f.Field == "HttpGet"
 	}

--- a/internal/lua/strenc_test.go
+++ b/internal/lua/strenc_test.go
@@ -141,3 +141,10 @@ func TestEncryptStrings_ParenthesizedHttpGetExcluded(t *testing.T) {
 		t.Fatalf("parenthesized HttpGet URL must NOT be encrypted: %q", out)
 	}
 }
+
+func TestEncryptStrings_LoadModuleExcluded(t *testing.T) {
+	out := encStr(t, `local M = loadModule("core/theme")`, 0x33)
+	if !contains(out, `"core/theme"`) {
+		t.Fatalf("loadModule key must NOT be encrypted: %q", out)
+	}
+}


### PR DESCRIPTION
## Why

Until now the bundler rewrote `require()`/`HttpGet` → `loadModule()` **only in the entry file**, so embedded modules could not require each other (the ez-rbx-ui entry documents this constraint). The rewriting was also a regex run *after* obfuscation/minification, making it fragile on single-line output.

> **Stacked on #42 → #41.** Review/merge those first; this PR re-targets automatically as they land.

## What

Lets modules `require` each other naturally, and makes rewriting robust by running it on readable source before minification.

- **Canonical module keys** — `canonicalKey(currentFile, modulePath)` resolves a module to a base-relative, cleaned, `.lua`-stripped key, so every spelling of the same file (`core/theme`, `../core/theme`, `core/theme.lua`, `/core/theme`) collapses to one embedded entry. Discovery keys/dedups by it. (Entry-funnel keys are unchanged — ez-rbx-ui's `core/theme` etc. stay identical.)
- **Per-unit rewriting, before obfuscation** — `rewriteModuleCalls(content, currentFile)` runs on each unit's raw source (entry **and** every local module body **and** HTTP module bodies), emitting `loadModule("<canonicalKey>")`. Removed from `generateBundle`. The function-wrapped-HttpGet skip now runs on readable text (robust). Module-call regexes hoisted to shared package vars.
- **Memoized `loadModule`** — caches results (`_cache`/`_cached`, nil/false-safe) so a shared module runs once, like Roblox `require`. Declared **before** the `EmbeddedModules` closures so they capture it as an upvalue (fixed a runtime bug where module bodies captured the nil global).
- **L3 exclusion** — `loadModule` keys are never string-encrypted (rewriting now precedes encryption).

## Verification

- New tests: `canonicalKey` spelling-collapse, canonical discovery keying, module-body rewrite + canonical keys, bare/quoted function-wrapped HttpGet skip, `loadModule` memoization + declaration order, L3 `loadModule` exclusion.
- **Cross-module runtime proof:** a project where entry→A→B and C→B (B not in the entry) bundles, embeds B once, and runs under lua5.1 printing `A=1 C=1 loads=1` (cross-module resolves AND shared module loads exactly once).
- **Remote-body proof:** a remote module that `HttpGet`s a leaf has its body rewritten to `loadModule` and resolves the embedded leaf (`remote.leaf=LEAF`).
- Whole Go suite green; `make verify-ezui` `[1/3]`/`[2/3]`/`[3/3]` all `VERIFY-BUNDLE OK` (entry-funnel + obfuscation + string-encryption regression).
- Final opus review: ready to merge; the one finding (HTTP bodies not rewritten) was found and fixed in this PR.

## Known limitations

Circular module graphs (`A→B→A`) are unsupported (same as Roblox `require`). Local `require` of an on-disk file from *inside* a remote module body is unsupported (no base path).
